### PR TITLE
Move end parenthesis to avoid warning in some shells

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -8,7 +8,8 @@ for dirpath, dirnames, files in os.walk(os.getcwd()):
         if file == "settings.gradle":
             os.chdir(dirpath)
             print(os.getcwd())
-END_SCRIPT)
+END_SCRIPT
+)
 
 ######## KTLINT-GRADLE HOOK START ########
 curl -s -L "https://raw.githubusercontent.com/adaptdk/am-ktlint-editorconfig/master/.editorconfig" > ${LOCATION}/.editorconfig


### PR DESCRIPTION
On linux errors are returned from most shells when attempting to execute this.

`/bin/sh` is a symbolic link to `/bin/dash`

Running pre-commit before this change results in:
```
git/hooks/pre-commit: 39: Syntax error: end of file unexpected (expecting ")")
```